### PR TITLE
Update new logz.io certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install awscli
 
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.6.2-amd64.deb && dpkg -i filebeat-7.6.2-amd64.deb
 RUN mkdir -p /etc/pki/tls/certs
-RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /etc/pki/tls/certs
+RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt -P /etc/pki/tls/certs
 
 RUN mkdir -p $POSTGRESQL_LOGS_DIR
 RUN mkdir -p $LOGZIO_LOGS_DIR

--- a/files/filebeat-rds.yml
+++ b/files/filebeat-rds.yml
@@ -45,7 +45,7 @@ output:
   logstash:
     hosts: ["${LOGZIO_LISTENER}:5015"]
     ssl:
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+      certificate_authorities: ['/etc/pki/tls/certs/TrustExternalCARoot_and_USERTrustRSAAAACA.crt']
 logging:
   to_files: true
   files:

--- a/files/filebeat.yml
+++ b/files/filebeat.yml
@@ -42,11 +42,11 @@ output:
     hosts: ["${LOGZIO_LISTENER}:5015"]
     #  The below configuration is used for Filebeat 1.3 or lower
     tls:
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+      certificate_authorities: ['/etc/pki/tls/certs/TrustExternalCARoot_and_USERTrustRSAAAACA.crt']
 
     #  The below configuration is used for Filebeat 5.0 or higher
     ssl:
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt']
+      certificate_authorities: ['/etc/pki/tls/certs/TrustExternalCARoot_and_USERTrustRSAAAACA.crt']
 logging:
   to_files: true
   files:


### PR DESCRIPTION
From 28 May Logz.io is replacing public certificates, this also affects on filebeat.
https://docs.logz.io/shipping/shippers/filebeat.html
Following PR contains a new certificate.